### PR TITLE
Add forgotten coverId

### DIFF
--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -293,6 +293,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'tags' => array_map(fn (string $tagId) => ['id' => $tagId, '_count' => 1], $tagIds),
                 'tagIds' => $tagIds,
                 'parentId' => $item['parentId'],
+                'coverId' => $item['coverId'],
                 'childCount' => (int) $item['childCount'],
                 'fullText' => $this->stripText(implode(' ', [$item['name'], $item['description'], $item['productNumber']])),
                 'fullTextBoosted' => $this->stripText(implode(' ', [$item['name'], $item['description'], $item['productNumber']])),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If you filter on coverId with elastic, the value is missing in the data.

### 2. What does this change do, exactly?
Bring back a working cover image filter.

### 3. Describe each step to reproduce the issue or behaviour.
Add a product stream that contains a has cover image filter.
This will result in no results, because the coverId is missing in the data of elastic.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.
